### PR TITLE
Allow building on Ubuntu 20.04

### DIFF
--- a/pidgin/libpurple/protocols/facebook/api.c
+++ b/pidgin/libpurple/protocols/facebook/api.c
@@ -3862,7 +3862,7 @@ fb_api_event_dup(const FbApiEvent *event, gboolean deep)
         return g_new0(FbApiEvent, 1);
     }
 
-    ret = g_memdup2(event, sizeof *event);
+    ret = g_memdup(event, sizeof *event);
 
     if (deep) {
         ret->text = g_strdup(event->text);


### PR DESCRIPTION
Ubuntu 20.04 comes with GLib 2.64. This fork uses g_memdup2, which was added in 2.68.

Could you please correctly #ifdef around the uses so that it is possible to build with older glib?

This PR is not an actual PR fixing the issue. But as issues are not available for this repo, this is one of the workarounds to contact you. I don't know meson build system enough to understand how to check for glib version and pass it to C preprocessor.