### PR TITLE
Ignore HTTP error code 410 and handle empty JSON gracefully

### DIFF
--- a/pidgin/libpurple/http.c
+++ b/pidgin/libpurple/http.c
@@ -2851,7 +2851,7 @@ gboolean purple_http_response_is_successful(PurpleHttpResponse *response)
 
 	/* TODO: HTTP/1.1 100 Continue */
 
-	if (code / 100 == 2 || code == 410)
+	if (code / 100 == 2 || code == 410 || code == 405)
 		return TRUE;
 
 	return FALSE;

--- a/pidgin/libpurple/http.c
+++ b/pidgin/libpurple/http.c
@@ -2851,7 +2851,7 @@ gboolean purple_http_response_is_successful(PurpleHttpResponse *response)
 
 	/* TODO: HTTP/1.1 100 Continue */
 
-	if (code / 100 == 2)
+	if (code / 100 == 2 || code == 410)
 		return TRUE;
 
 	return FALSE;

--- a/pidgin/libpurple/protocols/facebook/api.c
+++ b/pidgin/libpurple/protocols/facebook/api.c
@@ -864,7 +864,10 @@ fb_api_json_chk(FbApi *api, gconstpointer data, gssize size, JsonNode **node)
     priv = api->priv;
 
     if (G_UNLIKELY(size == 0)) {
-        fb_api_error(api, FB_API_ERROR_GENERAL, _("Empty JSON data"));
+        fb_util_debug(FB_UTIL_DEBUG_INFO, "Received empty JSON data. Ignoring.\n");
+        if (node != NULL) {
+            *node = NULL;
+        }
         return FALSE;
     }
 


### PR DESCRIPTION
Because it's gotten annoying that I get logged out whenever I'm supposed to receive an image. If images are no longer supported, so be it.

Temporary makeshift solution for #10 